### PR TITLE
Prevent repeatedly loading the BERT model from the disk.

### DIFF
--- a/text/chinese_bert.py
+++ b/text/chinese_bert.py
@@ -9,9 +9,9 @@ models = dict()
 
 def get_bert_feature(text, word2ph, device=None):
     if (
-            sys.platform == "darwin"
-            and torch.backends.mps.is_available()
-            and device == "cpu"
+        sys.platform == "darwin"
+        and torch.backends.mps.is_available()
+        and device == "cpu"
     ):
         device = "mps"
     if not device:

--- a/text/chinese_bert.py
+++ b/text/chinese_bert.py
@@ -4,24 +4,27 @@ from transformers import AutoTokenizer, AutoModelForMaskedLM
 
 tokenizer = AutoTokenizer.from_pretrained("./bert/chinese-roberta-wwm-ext-large")
 
+models = dict()
+
 
 def get_bert_feature(text, word2ph, device=None):
     if (
-        sys.platform == "darwin"
-        and torch.backends.mps.is_available()
-        and device == "cpu"
+            sys.platform == "darwin"
+            and torch.backends.mps.is_available()
+            and device == "cpu"
     ):
         device = "mps"
     if not device:
         device = "cuda"
-    model = AutoModelForMaskedLM.from_pretrained(
-        "./bert/chinese-roberta-wwm-ext-large"
-    ).to(device)
+    if device not in models.keys():
+        models[device] = AutoModelForMaskedLM.from_pretrained(
+            "./bert/chinese-roberta-wwm-ext-large"
+        ).to(device)
     with torch.no_grad():
         inputs = tokenizer(text, return_tensors="pt")
         for i in inputs:
             inputs[i] = inputs[i].to(device)
-        res = model(**inputs, output_hidden_states=True)
+        res = models[device](**inputs, output_hidden_states=True)
         res = torch.cat(res["hidden_states"][-3:-2], -1)[0].cpu()
 
     assert len(word2ph) == len(text) + 2

--- a/text/japanese_bert.py
+++ b/text/japanese_bert.py
@@ -4,24 +4,27 @@ import sys
 
 tokenizer = AutoTokenizer.from_pretrained("./bert/bert-base-japanese-v3")
 
+models = dict()
+
 
 def get_bert_feature(text, word2ph, device=None):
     if (
-        sys.platform == "darwin"
-        and torch.backends.mps.is_available()
-        and device == "cpu"
+            sys.platform == "darwin"
+            and torch.backends.mps.is_available()
+            and device == "cpu"
     ):
         device = "mps"
     if not device:
         device = "cuda"
-    model = AutoModelForMaskedLM.from_pretrained("./bert/bert-base-japanese-v3").to(
-        device
-    )
+    if device not in models.keys():
+        models[device] = AutoModelForMaskedLM.from_pretrained(
+            "./bert/bert-base-japanese-v3"
+        ).to(device)
     with torch.no_grad():
         inputs = tokenizer(text, return_tensors="pt")
         for i in inputs:
             inputs[i] = inputs[i].to(device)
-        res = model(**inputs, output_hidden_states=True)
+        res = models[device](**inputs, output_hidden_states=True)
         res = torch.cat(res["hidden_states"][-3:-2], -1)[0].cpu()
     assert inputs["input_ids"].shape[-1] == len(word2ph)
     word2phone = word2ph

--- a/text/japanese_bert.py
+++ b/text/japanese_bert.py
@@ -9,9 +9,9 @@ models = dict()
 
 def get_bert_feature(text, word2ph, device=None):
     if (
-            sys.platform == "darwin"
-            and torch.backends.mps.is_available()
-            and device == "cpu"
+        sys.platform == "darwin"
+        and torch.backends.mps.is_available()
+        and device == "cpu"
     ):
         device = "mps"
     if not device:


### PR DESCRIPTION
Prevent repeatedly loading the BERT model from the disk. As an alternative, keep BERT resident in GPU memory or RAM, which will significantly accelerate the speed of bert_gen.