### PR TITLE
使用配置文件配置bert_gen.py, preprocess_text.py, resample.py

### DIFF
--- a/bert_gen.py
+++ b/bert_gen.py
@@ -6,16 +6,11 @@ from tqdm import tqdm
 from text import cleaned_text_to_sequence, get_bert
 import argparse
 import torch.multiprocessing as mp
+from config import config
 
 
 def process_line(line):
-    rank = mp.current_process()._identity
-    rank = rank[0] if len(rank) > 0 else 0
-    if torch.cuda.is_available():
-        gpu_id = rank % torch.cuda.device_count()
-        device = torch.device(f"cuda:{gpu_id}")
-    else:
-        device = torch.device("cpu")
+    device = config.bert_gen_config.device
     wav_path, _, language_str, text, phones, tone, word2ph = line.strip().split("|")
     phone = phones.split(" ")
     tone = [int(i) for i in tone.split(" ")]
@@ -43,9 +38,13 @@ def process_line(line):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("-c", "--config", type=str, default="configs/config.json")
-    parser.add_argument("--num_processes", type=int, default=2)
-    args = parser.parse_args()
+    parser.add_argument(
+        "-c", "--config", type=str, default=config.bert_gen_config.config_path
+    )
+    parser.add_argument(
+        "--num_processes", type=int, default=config.bert_gen_config.num_processes
+    )
+    args, _ = parser.parse_known_args()
     config_path = args.config
     hps = utils.get_hparams_from_file(config_path)
     lines = []

--- a/bert_gen.py
+++ b/bert_gen.py
@@ -5,11 +5,20 @@ import utils
 from tqdm import tqdm
 from text import cleaned_text_to_sequence, get_bert
 import argparse
+import torch.multiprocessing as mp
 from config import config
 
 
 def process_line(line):
     device = config.bert_gen_config.device
+    if device == "multi":
+        rank = mp.current_process()._identity
+        rank = rank[0] if len(rank) > 0 else 0
+        if torch.cuda.is_available():
+            gpu_id = rank % torch.cuda.device_count()
+            device = torch.device(f"cuda:{gpu_id}")
+        else:
+            device = torch.device("cpu")
     wav_path, _, language_str, text, phones, tone, word2ph = line.strip().split("|")
     phone = phones.split(" ")
     tone = [int(i) for i in tone.split(" ")]

--- a/bert_gen.py
+++ b/bert_gen.py
@@ -5,7 +5,6 @@ import utils
 from tqdm import tqdm
 from text import cleaned_text_to_sequence, get_bert
 import argparse
-import torch.multiprocessing as mp
 from config import config
 
 

--- a/bert_gen.py
+++ b/bert_gen.py
@@ -11,7 +11,7 @@ from config import config
 
 def process_line(line):
     device = config.bert_gen_config.device
-    if device == "multi":
+    if config.bert_gen_config.use_multi_device:
         rank = mp.current_process()._identity
         rank = rank[0] if len(rank) > 0 else 0
         if torch.cuda.is_available():

--- a/config.py
+++ b/config.py
@@ -76,10 +76,12 @@ class Bert_gen_config:
         config_path: str,
         num_processes: int = 2,
         device: str = "cuda",
+        use_multi_device: bool = False,
     ):
         self.config_path = config_path
         self.num_processes = num_processes
         self.device = device
+        self.use_multi_device = use_multi_device
 
     @classmethod
     def from_dict(cls, dataset_path: str, data: Dict[str, any]):

--- a/config.py
+++ b/config.py
@@ -57,7 +57,10 @@ class Preprocess_text_config:
         data["transcription_path"] = os.path.join(
             dataset_path, data["transcription_path"]
         )
-        data["cleaned_path"] = os.path.join(dataset_path, data["cleaned_path"])
+        if data["cleaned_path"] == "" or data["cleaned_path"] is None:
+            data["cleaned_path"] = None
+        else:
+            data["cleaned_path"] = os.path.join(dataset_path, data["cleaned_path"])
         data["train_path"] = os.path.join(dataset_path, data["train_path"])
         data["val_path"] = os.path.join(dataset_path, data["val_path"])
         data["config_path"] = os.path.join(dataset_path, data["config_path"])
@@ -191,6 +194,7 @@ class Config:
 
 
 parser = argparse.ArgumentParser()
-parser.add_argument("-c", "--config", type=str, default="config.yml")
-args = parser.parse_args()
-config = Config(args.config)
+# 为避免与以前的config.json起冲突，将其更名如下
+parser.add_argument("-y", "--yml_config", type=str, default="config.yml")
+args, _ = parser.parse_known_args()
+config = Config(args.yml_config)

--- a/default_config.yml
+++ b/default_config.yml
@@ -26,16 +26,16 @@ preprocess_text:
   transcription_path: "filelists/你的数据集文本.list"
   # 数据清洗后文本路径，可以不填。不填则将在原始文本目录生成
   cleaned_path: ""
-  # 训练集路径，可以不填。不填则将在原始文本目录生成
-  train_path: ""
-  # 验证集路径，可以不填。不填则将在原始文本目录生成
-  val_path: ""
+  # 训练集路径
+  train_path: "filelists/train.list"
+  # 验证集路径
+  val_path: "filelists/val.list"
   # 配置文件路径
   config_path: "config.json"
   # 每个speaker的验证集条数
   val_per_spk: 5
   # 验证集最大条数，多于的会被截断并放到训练集中
-  max_val_total: 10000
+  max_val_total: 8
   # 是否进行数据清洗
   clean: true
 
@@ -48,14 +48,14 @@ bert_gen:
   # 并行数
   num_processes: 2
   # 使用设备：可选项 "cuda" 显卡推理， "cpu" cpu推理
-  # 此配置会影响所有使用bert的任务，包括bert_gen、train_ms、web_ui、api
+  # 该选项同时决定了get_bert_feature的默认设备
   device: "cuda"
 
 
 # train 训练配置
 # 注意， “:” 后需要加空格
 train_ms:
-  # 需要加载的环境变量，多显卡训练，RANK推荐手动填写
+  # 需要加载的环境变量，多显卡训练时RANK请手动在环境变量填写
   env:
     MASTER_ADDR: "localhost"
     MASTER_PORT: 10086

--- a/default_config.yml
+++ b/default_config.yml
@@ -47,7 +47,7 @@ bert_gen:
   config_path: "config.json"
   # 并行数
   num_processes: 2
-  # 使用设备：可选项 "cuda" 显卡推理， "cpu" cpu推理
+  # 使用设备：可选项 "cuda" 显卡推理， "multi" 多显卡推理 ，"cpu" cpu推理
   # 该选项同时决定了get_bert_feature的默认设备
   device: "cuda"
 

--- a/default_config.yml
+++ b/default_config.yml
@@ -47,9 +47,11 @@ bert_gen:
   config_path: "config.json"
   # 并行数
   num_processes: 2
-  # 使用设备：可选项 "cuda" 显卡推理， "multi" 多显卡推理 ，"cpu" cpu推理
+  # 使用设备：可选项 "cuda" 显卡推理，"cpu" cpu推理
   # 该选项同时决定了get_bert_feature的默认设备
   device: "cuda"
+  # 使用多卡推理
+  use_multi_device: false
 
 
 # train 训练配置

--- a/preprocess_text.py
+++ b/preprocess_text.py
@@ -7,25 +7,29 @@ from typing import Optional
 from tqdm import tqdm
 import click
 from text.cleaner import clean_text
+from config import config
+
+preprocess_text_config = config.preprocess_text_config
 
 
 @click.command()
 @click.option(
     "--transcription-path",
-    default="filelists/genshin.list",
+    default=preprocess_text_config.transcription_path,
     type=click.Path(exists=True, file_okay=True, dir_okay=False),
 )
-@click.option("--cleaned-path", default=None)
-@click.option("--train-path", default="filelists/train.list")
-@click.option("--val-path", default="filelists/val.list")
+@click.option("--cleaned-path", default=preprocess_text_config.cleaned_path)
+@click.option("--train-path", default=preprocess_text_config.train_path)
+@click.option("--val-path", default=preprocess_text_config.val_path)
 @click.option(
     "--config-path",
-    default="configs/config.json",
+    default=preprocess_text_config.config_path,
     type=click.Path(exists=True, file_okay=True, dir_okay=False),
 )
-@click.option("--val-per-spk", default=4)
-@click.option("--max-val-total", default=8)
-@click.option("--clean/--no-clean", default=True)
+@click.option("--val-per-spk", default=preprocess_text_config.val_per_spk)
+@click.option("--max-val-total", default=preprocess_text_config.max_val_total)
+@click.option("--clean/--no-clean", default=preprocess_text_config.clean)
+@click.option("-y", "--yml_config")
 def main(
     transcription_path: str,
     cleaned_path: Optional[str],
@@ -35,8 +39,10 @@ def main(
     val_per_spk: int,
     max_val_total: int,
     clean: bool,
+    yml_config: str,
 ):
-    if cleaned_path is None:
+    yml_config = ""  # 兼容config.py 防止被bot删除
+    if cleaned_path == "" or cleaned_path is None:
         cleaned_path = transcription_path + ".cleaned"
 
     if clean:

--- a/preprocess_text.py
+++ b/preprocess_text.py
@@ -41,7 +41,6 @@ def main(
     clean: bool,
     yml_config: str,
 ):
-    yml_config = ""  # 兼容config.py 防止被bot删除
     if cleaned_path == "" or cleaned_path is None:
         cleaned_path = transcription_path + ".cleaned"
 

--- a/resample.py
+++ b/resample.py
@@ -6,6 +6,8 @@ from multiprocessing import Pool, cpu_count
 import soundfile
 from tqdm import tqdm
 
+from config import config
+
 
 def process(item):
     spkdir, wav_name, args = item
@@ -19,14 +21,25 @@ def process(item):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("--sr", type=int, default=44100, help="sampling rate")
     parser.add_argument(
-        "--in_dir", type=str, default="./raw", help="path to source dir"
+        "--sr",
+        type=int,
+        default=config.resample_config.sampling_rate,
+        help="sampling rate",
     )
     parser.add_argument(
-        "--out_dir", type=str, default="./dataset", help="path to target dir"
+        "--in_dir",
+        type=str,
+        default=config.resample_config.in_dir,
+        help="path to source dir",
     )
-    args = parser.parse_args()
+    parser.add_argument(
+        "--out_dir",
+        type=str,
+        default=config.resample_config.out_dir,
+        help="path to target dir",
+    )
+    args, _ = parser.parse_known_args()
     # processes = 8
     processes = cpu_count() - 2 if cpu_count() > 4 else 1
     pool = Pool(processes=processes)

--- a/text/chinese_bert.py
+++ b/text/chinese_bert.py
@@ -1,13 +1,14 @@
 import torch
 import sys
 from transformers import AutoTokenizer, AutoModelForMaskedLM
+from config import config
 
 tokenizer = AutoTokenizer.from_pretrained("./bert/chinese-roberta-wwm-ext-large")
 
 models = dict()
 
 
-def get_bert_feature(text, word2ph, device=None):
+def get_bert_feature(text, word2ph, device=config.bert_gen_config.device):
     if (
         sys.platform == "darwin"
         and torch.backends.mps.is_available()

--- a/text/japanese_bert.py
+++ b/text/japanese_bert.py
@@ -2,13 +2,14 @@ import torch
 from transformers import AutoTokenizer, AutoModelForMaskedLM
 import sys
 from text.japanese import text2sep_kata
+from config import config
 
 tokenizer = AutoTokenizer.from_pretrained("./bert/bert-base-japanese-v3")
 
 models = dict()
 
 
-def get_bert_feature(text, word2ph, device=None):
+def get_bert_feature(text, word2ph, device=config.bert_gen_config.device):
     sep_text, _ = text2sep_kata(text)
     sep_tokens = [tokenizer.tokenize(t) for t in sep_text]
     sep_ids = [tokenizer.convert_tokens_to_ids(t) for t in sep_tokens]
@@ -16,7 +17,7 @@ def get_bert_feature(text, word2ph, device=None):
     return get_bert_feature_with_token(sep_ids, word2ph, device)
 
 
-def get_bert_feature_with_token(tokens, word2ph, device=None):
+def get_bert_feature_with_token(tokens, word2ph, device=config.bert_gen_config.device):
     if (
         sys.platform == "darwin"
         and torch.backends.mps.is_available()


### PR DESCRIPTION
#62 的后续工作，提供使用配置文件`config.yml`的方式对`bert_gen`、`preprocess_text`、`resample`进行配置。考虑到一些开发者可能更倾向于使用命令行，因此保留了原有的命令行参数配置。   

后续将支持`train_ms` 与 `server`