### PR TITLE
Fix bug in oldVersion.

### DIFF
--- a/oldVersion/V101/__init__.py
+++ b/oldVersion/V101/__init__.py
@@ -6,7 +6,7 @@ import torch
 import commons
 from .text.cleaner import clean_text
 from .text import cleaned_text_to_sequence
-from text import get_bert
+from .text import get_bert
 
 
 def get_text(text, language_str, hps, device):

--- a/oldVersion/V110/__init__.py
+++ b/oldVersion/V110/__init__.py
@@ -6,7 +6,7 @@ import torch
 import commons
 from .text.cleaner import clean_text
 from .text import cleaned_text_to_sequence
-from text import get_bert
+from .text import get_bert
 
 
 def get_text(text, language_str, hps, device):

--- a/oldVersion/V111/__init__.py
+++ b/oldVersion/V111/__init__.py
@@ -6,7 +6,7 @@ import torch
 import commons
 from .text.cleaner import clean_text
 from .text import cleaned_text_to_sequence
-from text import get_bert
+from .text import get_bert
 
 
 def get_text(text, language_str, hps, device):


### PR DESCRIPTION
因为新版本中`get_bert()`出现变动，因此旧版本推理不再共用`get_bert`，而是使用对应版本的实现。