### PR TITLE
Fix: server_fastapi.py.

### DIFF
--- a/server_fastapi.py
+++ b/server_fastapi.py
@@ -26,6 +26,8 @@ import tools.translate as trans
 
 from config import config
 
+os.environ["TOKENIZERS_PARALLELISM"] = "false"
+
 
 class Model:
     """模型封装类"""


### PR DESCRIPTION
在linux服务器上推理2.0日语模型报错，进行修正