### PR TITLE
Fix multiprocess

### DIFF
--- a/bert_gen.py
+++ b/bert_gen.py
@@ -66,7 +66,7 @@ if __name__ == "__main__":
     with open(hps.data.validation_files, encoding="utf-8") as f:
         lines.extend(f.readlines())
     if len(lines) != 0:
-        num_processes = min(args.num_processes, cpu_count() - 1)
+        num_processes = min(args.num_processes, cpu_count())
         with Pool(processes=num_processes) as pool:
             for _ in tqdm(pool.imap_unordered(process_line, lines), total=len(lines)):
                 pass

--- a/bert_gen.py
+++ b/bert_gen.py
@@ -66,7 +66,7 @@ if __name__ == "__main__":
     with open(hps.data.validation_files, encoding="utf-8") as f:
         lines.extend(f.readlines())
     if len(lines) != 0:
-        num_processes = min(args.num_processes, cpu_count()-1)
+        num_processes = min(args.num_processes, cpu_count() - 1)
         with Pool(processes=num_processes) as pool:
             for _ in tqdm(pool.imap_unordered(process_line, lines), total=len(lines)):
                 pass

--- a/bert_gen.py
+++ b/bert_gen.py
@@ -1,12 +1,14 @@
+import argparse
+from multiprocessing import Pool, cpu_count
+
 import torch
-from multiprocessing import Pool
+import torch.multiprocessing as mp
+from tqdm import tqdm
+
 import commons
 import utils
-from tqdm import tqdm
-from text import cleaned_text_to_sequence, get_bert
-import argparse
-import torch.multiprocessing as mp
 from config import config
+from text import cleaned_text_to_sequence, get_bert
 
 
 def process_line(line):
@@ -64,7 +66,7 @@ if __name__ == "__main__":
     with open(hps.data.validation_files, encoding="utf-8") as f:
         lines.extend(f.readlines())
     if len(lines) != 0:
-        num_processes = args.num_processes
+        num_processes = min(args.num_processes, cpu_count()-1)
         with Pool(processes=num_processes) as pool:
             for _ in tqdm(pool.imap_unordered(process_line, lines), total=len(lines)):
                 pass

--- a/emo_gen.py
+++ b/emo_gen.py
@@ -149,7 +149,12 @@ if __name__ == "__main__":
 
     wavnames = [line.split("|")[0] for line in lines]
     dataset = AudioDataset(wavnames, 16000, processor)
-    data_loader = DataLoader(dataset, batch_size=1, shuffle=False, num_workers=16)
+    data_loader = DataLoader(
+        dataset,
+        batch_size=1,
+        shuffle=False,
+        num_workers=min(args.num_processes, os.cpu_count() - 1),
+    )
 
     with torch.no_grad():
         for i, data in tqdm(enumerate(data_loader), total=len(data_loader)):

--- a/text/__init__.py
+++ b/text/__init__.py
@@ -48,4 +48,11 @@ def check_bert_models():
             _check_bert(v["repo_id"], v["files"], local_path)
 
 
+def init_openjtalk():
+    import pyopenjtalk
+
+    pyopenjtalk.g2p("こんにちは，世界。")
+
+
+init_openjtalk()
 check_bert_models()


### PR DESCRIPTION
- `bert_gen.py`: 优化多线程；修复`bert_gen`在`pyopenjtalk`未初始化时多线程同时下载字典导致`pyopenjtalk`损坏的bug
- `emo_gen.py`: `args.num_processes`没传入到`dataloader`，小改了一下