### PR TITLE
修复了VQ未注册入网络的问题

### DIFF
--- a/models.py
+++ b/models.py
@@ -345,16 +345,18 @@ class TextEncoder(nn.Module):
         self.ja_bert_proj = nn.Conv1d(1024, hidden_channels, 1)
         self.en_bert_proj = nn.Conv1d(1024, hidden_channels, 1)
         self.emo_proj = nn.Linear(1024, 1024)
-        self.emo_quantizer = [
-            VectorQuantize(
-                dim=1024,
-                codebook_size=10,
-                decay=0.8,
-                commitment_weight=1.0,
-                learnable_codebook=True,
-                ema_update=False,
+        self.emo_quantizer = nn.ModuleList()
+        for i in range(0, n_speakers):
+            self.emo_quantizer.append(
+                    VectorQuantize(
+                    dim=1024,
+                    codebook_size=10,
+                    decay=0.8,
+                    commitment_weight=1.0,
+                    learnable_codebook=True,
+                    ema_update=False,
+                )
             )
-        ] * n_speakers
         self.emo_q_proj = nn.Linear(1024, hidden_channels)
 
         self.encoder = attentions.Encoder(


### PR DESCRIPTION
使用Python的基础容器嵌套Module，并不会将Module注册入网络。这会导致传递梯度或保存和加载模型时直接忽略这些Module，这也是之前VQ使Emo完全失效的原因。