### PR TITLE
fix mismatch when there is space between alpha and non-alpha words

### DIFF
--- a/tools/classify_language.py
+++ b/tools/classify_language.py
@@ -162,9 +162,9 @@ def classify_zh_ja(text: str) -> str:
 
 def split_alpha_nonalpha(text, mode=1):
     if mode == 1:
-        pattern = r"(?<=[\u4e00-\u9fff\u3040-\u30FF\d])(?=[\p{Latin}])|(?<=[\p{Latin}])(?=[\u4e00-\u9fff\u3040-\u30FF\d])"
+        pattern = r"(?<=[\u4e00-\u9fff\u3040-\u30FF\d\s])(?=[\p{Latin}])|(?<=[\p{Latin}\s])(?=[\u4e00-\u9fff\u3040-\u30FF\d])"
     elif mode == 2:
-        pattern = r"(?<=[\u4e00-\u9fff\u3040-\u30FF])(?=[\p{Latin}\d])|(?<=[\p{Latin}\d])(?=[\u4e00-\u9fff\u3040-\u30FF])"
+        pattern = r"(?<=[\u4e00-\u9fff\u3040-\u30FF\s])(?=[\p{Latin}\d])|(?<=[\p{Latin}\d\s])(?=[\u4e00-\u9fff\u3040-\u30FF])"
     else:
         raise ValueError("Invalid mode. Supported modes are 1 and 2.")
 
@@ -187,3 +187,11 @@ if __name__ == "__main__":
 
     print(split_alpha_nonalpha(text, mode=2))
     # output: ['vits', '和', 'Bert-VITS2', '是', 'tts', '模型。花费', '3days.花费', '3', '天。Take 3 days']
+
+    text = "vits 和 Bert-VITS2 是 tts 模型。花费3days.花费3天。Take 3 days"
+    print(split_alpha_nonalpha(text, mode=1))
+    # output: ['vits ', '和 ', 'Bert-VITS', '2 ', '是 ', 'tts ', '模型。花费3', 'days.花费3天。Take ', '3 ', 'days']
+
+    text = "vits 和 Bert-VITS2 是 tts 模型。花费3days.花费3天。Take 3 days"
+    print(split_alpha_nonalpha(text, mode=2))
+    # output: ['vits ', '和 ', 'Bert-VITS2 ', '是 ', 'tts ', '模型。花费', '3days.花费', '3', '天。Take ', '3 ', 'days']

--- a/tools/sentence.py
+++ b/tools/sentence.py
@@ -90,6 +90,7 @@ def split_by_language(text: str, target_languages: list = None) -> list:
         end += len(sentence)
         pre_lang = lang
     sentences_list.append((text[start:], pre_lang))
+
     return sentences_list
 
 

--- a/tools/sentence.py
+++ b/tools/sentence.py
@@ -171,4 +171,3 @@ if __name__ == "__main__":
     text = "vits 和 Bert-VITS2 是 tts 模型。花费 3 days. 花费 3天。Take 3 days"
     print(split_by_language(text, ["zh", "en"]))
     # output: [('vits ', 'en'), ('和 ', 'zh'), ('Bert-VITS2 ', 'en'), ('是 ', 'zh'), ('tts ', 'en'), ('模型。花费 ', 'zh'), ('3 days. ', 'en'), ('花费 3天。', 'zh'), ('Take 3 days', 'en')]
-

--- a/tools/sentence.py
+++ b/tools/sentence.py
@@ -90,7 +90,6 @@ def split_by_language(text: str, target_languages: list = None) -> list:
         end += len(sentence)
         pre_lang = lang
     sentences_list.append((text[start:], pre_lang))
-
     return sentences_list
 
 
@@ -167,3 +166,8 @@ if __name__ == "__main__":
 
     print(split_by_language(text, ["zh", "en"]))
     # output: [('vits', 'en'), ('和', 'zh'), ('Bert-VITS', 'en'), ('2是', 'zh'), ('tts', 'en'), ('模型。花费3', 'zh'), ('days.', 'en'), ('花费3天。', 'zh'), ('Take 3 days', 'en')]
+
+    text = "vits 和 Bert-VITS2 是 tts 模型。花费 3 days. 花费 3天。Take 3 days"
+    print(split_by_language(text, ["zh", "en"]))
+    # output: [('vits ', 'en'), ('和 ', 'zh'), ('Bert-VITS2 ', 'en'), ('是 ', 'zh'), ('tts ', 'en'), ('模型。花费 ', 'zh'), ('3 days. ', 'en'), ('花费 3天。', 'zh'), ('Take 3 days', 'en')]
+


### PR DESCRIPTION
It is common and more formal that people add spaces between alpha and non-alpha words. For example:

case 1:
```
vits和Bert-VITS2是tts模型。
```

case 2:

```
vits 和 Bert-VITS2 是 tts 模型。
```

Case 2 should also be treated correctly, but previous code did not correctly split the English and Chinese words  with case 2 input. A fix is to add a "\s" to the regex in `split_alpha_nonalpha`.

Please let me know if I miss something or you have any suggestions :)