### PR TITLE
在每次epoch结束后回收显存以避免显存溢出

### DIFF
--- a/train_ms.py
+++ b/train_ms.py
@@ -13,6 +13,7 @@ import logging
 from config import config
 import argparse
 import datetime
+import gc
 
 logging.getLogger("numba").setLevel(logging.WARNING)
 import commons
@@ -590,7 +591,8 @@ def train_and_evaluate(
                     )
 
         global_step += 1
-
+    gc.collect()
+    torch.cuda.empty_cache()
     if rank == 0:
         logger.info("====> Epoch: {}".format(epoch))
 


### PR DESCRIPTION
# 问题
大佬好，我是萌新。我用我的4090在初次clone这个repo（2.1版本）的时候，一开始还能好好训练的，大概十几个epoch之后就显存溢出，然后重新从检查点加载时再也训不动了，都爆内存溢出。
# 改进
因此我在每次epoch结束后回收显存以避免显存溢出的问题。
# 结论
代码加了之后倒是能跑了，每轮epoch把把贴着显存上限走hhh，虽说调小batchsize应该就行，不过还是加了这个以争取更大的batchsize。

--- 
不过只有3行代码，第一次提交这种PR，望指教，谢谢~