### PR TITLE
Fix: infer.py 修正旧版本推理

### DIFF
--- a/infer.py
+++ b/infer.py
@@ -12,6 +12,7 @@ import commons
 from text import cleaned_text_to_sequence, get_bert
 
 # from clap_wrapper import get_clap_audio_feature, get_clap_text_feature
+from typing import Union, Optional
 from text.cleaner import clean_text
 import utils
 
@@ -147,22 +148,22 @@ def get_text(text, language_str, hps, device, style_text=None, style_weight=0.7)
 
 
 def infer(
-    text,
-    emotion,
-    sdp_ratio,
-    noise_scale,
-    noise_scale_w,
-    length_scale,
-    sid,
-    language,
-    hps,
-    net_g,
-    device,
-    reference_audio=None,
-    skip_start=False,
-    skip_end=False,
-    style_text=None,
-    style_weight=0.7,
+        text,
+        emotion: Union[int, str],
+        sdp_ratio,
+        noise_scale,
+        noise_scale_w,
+        length_scale,
+        sid,
+        language,
+        hps,
+        net_g,
+        device,
+        reference_audio=None,
+        skip_start=False,
+        skip_end=False,
+        style_text=None,
+        style_weight=0.7,
 ):
     # 2.2版本参数位置变了
     inferMap_V4 = {
@@ -193,7 +194,6 @@ def infer(
     # 非当前版本，根据版本号选择合适的infer
     if version != latest_version:
         if version in inferMap_V4.keys():
-            emotion = ""  # Use empty emotion prompt
             return inferMap_V4[version](
                 text,
                 emotion,
@@ -213,7 +213,6 @@ def infer(
                 style_weight,
             )
         if version in inferMap_V3.keys():
-            emotion = 0
             return inferMap_V3[version](
                 text,
                 sdp_ratio,
@@ -333,20 +332,20 @@ def infer(
 
 
 def infer_multilang(
-    text,
-    sdp_ratio,
-    noise_scale,
-    noise_scale_w,
-    length_scale,
-    sid,
-    language,
-    hps,
-    net_g,
-    device,
-    reference_audio=None,
-    emotion=None,
-    skip_start=False,
-    skip_end=False,
+        text,
+        sdp_ratio,
+        noise_scale,
+        noise_scale_w,
+        length_scale,
+        sid,
+        language,
+        hps,
+        net_g,
+        device,
+        reference_audio=None,
+        emotion=None,
+        skip_start=False,
+        skip_end=False,
 ):
     bert, ja_bert, en_bert, phones, tones, lang_ids = [], [], [], [], [], []
     # emo = get_emo_(reference_audio, emotion, sid)

--- a/infer.py
+++ b/infer.py
@@ -12,7 +12,7 @@ import commons
 from text import cleaned_text_to_sequence, get_bert
 
 # from clap_wrapper import get_clap_audio_feature, get_clap_text_feature
-from typing import Union, Optional
+from typing import Union
 from text.cleaner import clean_text
 import utils
 
@@ -148,22 +148,22 @@ def get_text(text, language_str, hps, device, style_text=None, style_weight=0.7)
 
 
 def infer(
-        text,
-        emotion: Union[int, str],
-        sdp_ratio,
-        noise_scale,
-        noise_scale_w,
-        length_scale,
-        sid,
-        language,
-        hps,
-        net_g,
-        device,
-        reference_audio=None,
-        skip_start=False,
-        skip_end=False,
-        style_text=None,
-        style_weight=0.7,
+    text,
+    emotion: Union[int, str],
+    sdp_ratio,
+    noise_scale,
+    noise_scale_w,
+    length_scale,
+    sid,
+    language,
+    hps,
+    net_g,
+    device,
+    reference_audio=None,
+    skip_start=False,
+    skip_end=False,
+    style_text=None,
+    style_weight=0.7,
 ):
     # 2.2版本参数位置变了
     inferMap_V4 = {
@@ -332,20 +332,20 @@ def infer(
 
 
 def infer_multilang(
-        text,
-        sdp_ratio,
-        noise_scale,
-        noise_scale_w,
-        length_scale,
-        sid,
-        language,
-        hps,
-        net_g,
-        device,
-        reference_audio=None,
-        emotion=None,
-        skip_start=False,
-        skip_end=False,
+    text,
+    sdp_ratio,
+    noise_scale,
+    noise_scale_w,
+    length_scale,
+    sid,
+    language,
+    hps,
+    net_g,
+    device,
+    reference_audio=None,
+    emotion=None,
+    skip_start=False,
+    skip_end=False,
 ):
     bert, ja_bert, en_bert, phones, tones, lang_ids = [], [], [], [], [], []
     # emo = get_emo_(reference_audio, emotion, sid)


### PR DESCRIPTION
修正`2.1`、`2.2`的错误emotion输入。推测之前这么写可能是为了让`webui`能推理`2.1`、`2.2`的模型。如果需要用`webui.py`推理旧版本模型的话推荐还是直接用老版本的`webui.py`。毕竟新版本的`webui`应该是把之前的`emotion`输入框删了。