### PR TITLE
Free up memory left by failed inference 

### DIFF
--- a/onnx_modules/V240/models_onnx.py
+++ b/onnx_modules/V240/models_onnx.py
@@ -355,7 +355,9 @@ class TextEncoder(nn.Module):
 
     def forward(self, x, x_lengths, tone, language, bert, emo, g=None):
         x_mask = torch.ones_like(x).unsqueeze(0)
-        bert_emb = self.bert_proj(self.bert_pre_proj(bert.transpose(0, 1).unsqueeze(0))).transpose(1, 2)
+        bert_emb = self.bert_proj(
+            self.bert_pre_proj(bert.transpose(0, 1).unsqueeze(0))
+        ).transpose(1, 2)
         emo_emb = self.in_feature_net(emo)
         emo_emb, _, _ = self.emo_vq(emo_emb.unsqueeze(1))
         emo_emb = self.out_feature_net(emo_emb)
@@ -816,7 +818,7 @@ class SynthesizerTrn(nn.Module):
         n_layers_trans_flow=6,
         flow_share_parameter=False,
         use_transformer_flow=True,
-        **kwargs
+        **kwargs,
     ):
         super().__init__()
         self.n_vocab = n_vocab
@@ -1007,9 +1009,7 @@ class SynthesizerTrn(nn.Module):
             opset_version=16,
         )
 
-        x, m_p, logs_p, x_mask = self.enc_p(
-            x, x_lengths, tone, language, bert, emo, g
-        )
+        x, m_p, logs_p, x_mask = self.enc_p(x, x_lengths, tone, language, bert, emo, g)
 
         zinput = (
             torch.randn(x.size(0), 2, x.size(2)).to(device=x.device, dtype=x.dtype)

--- a/onnx_modules/__init__.py
+++ b/onnx_modules/__init__.py
@@ -36,10 +36,10 @@ def export_onnx(export_path, model_path, config_path, novq, dev):
 
     LangDict = {"ZH": [0, 0], "JP": [1, 6], "EN": [2, 8]}
     BertPaths = [
-            "chinese-roberta-wwm-ext-large",
-            "deberta-v2-large-japanese",
-            "bert-base-japanese-v3",
-        ]
+        "chinese-roberta-wwm-ext-large",
+        "deberta-v2-large-japanese",
+        "bert-base-japanese-v3",
+    ]
     if version == "2.4":
         LangDict = {"ZH": [0, 0]}
         BertPaths = ["chinese-roberta-wwm-ext-large"]


### PR DESCRIPTION
# Issue Resolved

When an inference run fails, e.g. when exceeding GPU memory limit, the model's `infer` method will could throw an exception at [e.g. net_g.infer(...)](https://github.com/dyzfromyt/Bert-VITS2/blob/37c34f3e69589c70ca5097a4b5733f08fa353c18/oldVersion/V200/__init__.py#L76) and skipping the subsequent variable deletion and GPU memory release at [e.g. del x_tst, tones ...](https://github.com/dyzfromyt/Bert-VITS2/blob/37c34f3e69589c70ca5097a4b5733f08fa353c18/oldVersion/V200/__init__.py#L95C9-L95C25)

A subsequent inference run could fail before the next Python garbage collector run due to not enough memory on GPU.

# Repro steps

1. Run WebUI
2. Generate audio on a long text that could exceed GPU memory limit
3. The generation should fail
4. Replace the text with a much short text that should normally succeed in audio generation

Expected: Should be able to generate audio for the short text
Actual: Audio generation fails due to not enough memory

# Proposed Solution Here

Explicitly call garbage collector to free up memory before inference. This would allow new inference run to succeed.

# Test done
I manually run through repro steps and able to generate audio for short text after failed long text audio inference run