### PR TITLE
fix(default_config.yml): train_ms config_path

### DIFF
--- a/default_config.yml
+++ b/default_config.yml
@@ -87,7 +87,7 @@ train_ms:
   # 训练模型存储目录：与旧版本的区别，原先数据集是存放在logs/model_name下的，现在改为统一存放在Data/你的数据集/models下
   model: "models"
   # 配置文件路径
-  config_path: "config.json"
+  config_path: "configs/config.json"
   # 训练使用的worker，不建议超过CPU核心数
   num_workers: 16
   # 关闭此项可以节约接近70%的磁盘空间，但是可能导致实际训练速度变慢和更高的CPU使用率。

--- a/default_config.yml
+++ b/default_config.yml
@@ -104,7 +104,7 @@ webui:
   # 模型路径
   model: "models/G_8000.pth"
   # 配置文件路径
-  config_path: "config.json"
+  config_path: "configs/config.json"
   # 端口号
   port: 7860
   # 是否公开部署，对外网开放


### PR DESCRIPTION
[webui_preprocess.py](https://github.com/fishaudio/Bert-VITS2/blob/master/webui_preprocess.py#L24) 生成的配置文件路径是 `数据集/configs/config.json`
![image](https://github.com/fishaudio/Bert-VITS2/assets/109729945/8fd8e5d6-3aa9-4e2d-bc9d-62e23d7d42a3)


这个默认配置应该要改一下，不知道会不会影响其他地方，麻烦帮忙看一下