### PR TITLE
fix: use torch.amp via compatibility shim to avoid deprecated torch.cuda.amp warnings

### DIFF
--- a/train_ms.py
+++ b/train_ms.py
@@ -7,7 +7,19 @@ from torch.utils.data import DataLoader
 from torch.utils.tensorboard import SummaryWriter
 import torch.distributed as dist
 from torch.nn.parallel import DistributedDataParallel as DDP
-from torch.cuda.amp import autocast, GradScaler
+
+if hasattr(torch.amp, "autocast") and hasattr(torch.amp, "GradScaler"):
+    from torch.amp import autocast as _amp_autocast
+    from torch.amp import GradScaler
+
+    def autocast(*args, **kwargs):
+        """torch.amp.autocast with device_type defaulting to "cuda"."""
+        if not args and "device_type" not in kwargs:
+            kwargs["device_type"] = "cuda"
+        return _amp_autocast(*args, **kwargs)
+
+else:
+    from torch.cuda.amp import autocast, GradScaler
 from tqdm import tqdm
 import logging
 from config import config


### PR DESCRIPTION
## Summary

`torch.cuda.amp.autocast` has been deprecated since torch 2.4 and `torch.cuda.amp.GradScaler` since torch 2.3. Both still work but emit a `FutureWarning`; the replacement device-agnostic APIs live in `torch.amp`.

**Why migrate now, beyond warning noise:** `requirements.txt` has no torch entry (torch is installed ad-hoc per user environment), so nothing bounds which torch a user runs — on the current PyPI release the `FutureWarning` fires on every training step, including the default config (`GradScaler(enabled=...)` at train_ms.py:349 and the 6 `with autocast(...)` blocks emit at construction time regardless of the `bf16_run` flag). When torch removes `torch.cuda.amp` ("will be removed in a future release", no version pinned), this top-level import raises `ImportError` and training breaks at startup.

Changes:
- Replaces the `from torch.cuda.amp import autocast, GradScaler` import with a compatibility shim: when torch >= 2.3 provides both names in `torch.amp`, import them from there; otherwise fall back to `torch.cuda.amp`.
- The shim defaults `device_type="cuda"` for `autocast`, matching the old `torch.cuda.amp.autocast` signature — all 6 existing call sites (`with autocast(enabled=..., dtype=...)`) work unchanged.

## Type of change

- [x] Bug fix — deprecated API usage that becomes a hard `ImportError` when torch removes `torch.cuda.amp`
- [ ] Documentation
- [ ] Other

## Validation

Verified on torch 2.11.0 with `warnings.simplefilter("error", FutureWarning)`, by extracting the shim block from train_ms.py and executing it:

- New path (torch >= 2.3): `with autocast(enabled=True, dtype=torch.bfloat16):`, `with autocast("cuda", enabled=True):`, `GradScaler(enabled=True)` — no FutureWarning; imports resolve to `torch.amp.autocast_mode` / `torch.amp.grad_scaler`
- Control: the same filter makes the old `torch.cuda.amp.autocast(enabled=True)` raise `FutureWarning` — proving the filter is sensitive
- Fallback path (torch < 2.3, simulated by removing `autocast`/`GradScaler` from `torch.amp`): falls back to `torch.cuda.amp`, same call-site signatures work
- `black` 26.5.1 `--check`: clean (same version as the repo's pre-commit hook)
- `python -m compileall train_ms.py`: passes

## User impact

No behavior change on any torch version. On torch >= 2.3 (the deprecation range) training no longer emits the `FutureWarning`; when torch eventually removes `torch.cuda.amp`, the import keeps working instead of raising `ImportError` at startup.

## Notes for reviewers

- Migration boundary is 2.3, not 2.0: the shim imports both `autocast` and `GradScaler` from `torch.amp` together, and `GradScaler` only exists there since 2.3.
- `torch.amp.autocast` requires a positional `device_type` that the old API did not; the shim defaults it to `"cuda"` so the 6 call sites are untouched.
- The 13 `GradScaler` method calls (scale/unscale_/step/update) are untouched — same API.

## Reference

- [PyTorch AMP docs](https://pytorch.org/docs/stable/amp.html) — official deprecation notice (`torch.cuda.amp.autocast` / `GradScaler` deprecated since 2.4 / 2.3, "will be removed in a future release")

- [huggingface/lerobot#3167](https://github.com/huggingface/lerobot/pull/3167) — same migration in LeRobot, merged

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/fishaudio/codesmith/Bert-VITS2/pr/457"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789830334&installation_model_id=430858&pr_number=457&repository=fishaudio%2FBert-VITS2&return_to=https%3A%2F%2Fgithub.com%2Ffishaudio%2FBert-VITS2%2Fpull%2F457&signature=922a9788561be789439254e5c8fe8dd463fa07e5c484d9e36ca7fce0b3b7ab56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->